### PR TITLE
Add PandaSpigotUpdater

### DIFF
--- a/lib/src/main/java/me/hsgamer/mcserverupdater/UpdateBuilder.java
+++ b/lib/src/main/java/me/hsgamer/mcserverupdater/UpdateBuilder.java
@@ -32,6 +32,7 @@ public final class UpdateBuilder {
         registerUpdater(versionQuery -> new PaperUpdater(versionQuery, "waterfall"), "waterfall");
         registerUpdater(versionQuery -> new PaperUpdater(versionQuery, "velocity"), "velocity");
         registerUpdater(versionQuery -> new PaperUpdater(versionQuery, "folia"), "folia");
+        registerUpdater(versionQuery -> new PandaSpigotUpdater(versionQuery, "pandaspigot"), "pandaspigot");
         registerUpdater(PurpurUpdater::new, "purpur", "purpurmc");
         registerUpdater(BungeeCordUpdater::new, "bungeecord", "bungee");
         registerUpdater(SpigotUpdater::new, "spigot", "spigotmc");

--- a/lib/src/main/java/me/hsgamer/mcserverupdater/updater/PandaSpigotUpdater.java
+++ b/lib/src/main/java/me/hsgamer/mcserverupdater/updater/PandaSpigotUpdater.java
@@ -1,0 +1,117 @@
+package me.hsgamer.mcserverupdater.updater;
+
+import me.hsgamer.hscore.logger.common.Logger;
+import me.hsgamer.hscore.web.UserAgent;
+import me.hsgamer.hscore.web.WebUtils;
+import me.hsgamer.mcserverupdater.UpdateBuilder;
+import me.hsgamer.mcserverupdater.api.FileDigestChecksum;
+import me.hsgamer.mcserverupdater.api.InputStreamUpdater;
+import me.hsgamer.mcserverupdater.util.VersionQuery;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLConnection;
+import java.security.MessageDigest;
+
+public class PandaSpigotUpdater implements InputStreamUpdater, FileDigestChecksum {
+    private final UpdateBuilder updateBuilder;
+    private final String version;
+    private final String build;
+    private final String projectUrl;
+    private final String versionUrl;
+    private final String buildUrl;
+    private final String downloadUrl;
+
+    public PandaSpigotUpdater(VersionQuery versionQuery, String project) {
+        this.updateBuilder = versionQuery.updateBuilder;
+        projectUrl = String.format("https://downloads.hpfxd.com/v2/projects/%s", project);
+        versionUrl = projectUrl + "/versions/%s";
+        buildUrl = versionUrl + "/builds/%s";
+        downloadUrl = buildUrl + "/downloads/paperclip";
+
+        version = versionQuery.isDefault ? getDefaultVersion() : versionQuery.version;
+        build = getBuild();
+    }
+
+    private String getDefaultVersion() {
+        updateBuilder.debug("Getting default version from " + projectUrl);
+        try {
+            URLConnection connection = UserAgent.CHROME.assignToConnection(WebUtils.createConnection(projectUrl));
+            InputStream inputStream = connection.getInputStream();
+            JSONObject jsonObject = new JSONObject(new JSONTokener(inputStream));
+            JSONArray builds = jsonObject.getJSONArray("versions");
+            return builds.getString(builds.length() - 1);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String getBuild() {
+        String formattedUrl = String.format(versionUrl, version);
+        updateBuilder.debug("Getting latest build from " + formattedUrl);
+        try {
+            URLConnection connection = UserAgent.CHROME.assignToConnection(WebUtils.createConnection(formattedUrl));
+            InputStream inputStream = connection.getInputStream();
+            JSONObject jsonObject = new JSONObject(new JSONTokener(inputStream));
+            JSONArray builds = jsonObject.getJSONArray("builds");
+            return Integer.toString(builds.getInt(builds.length() - 1));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private JSONObject getDownload() throws IOException {
+        String formattedUrl = String.format(buildUrl, version, build);
+        updateBuilder.debug("Getting download from " + formattedUrl);
+        URLConnection connection = UserAgent.CHROME.assignToConnection(WebUtils.createConnection(formattedUrl));
+        InputStream inputStream = connection.getInputStream();
+        JSONObject jsonObject = new JSONObject(new JSONTokener(inputStream));
+        JSONObject downloads = jsonObject.getJSONObject("downloads");
+        return downloads.getJSONObject("paperclip");
+    }
+
+    @Override
+    public String getChecksum() {
+        try {
+            JSONObject paperclip = getDownload();
+            return paperclip.getString("sha256");
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    @Override
+    public MessageDigest getMessageDigest() throws Exception {
+        return MessageDigest.getInstance("SHA-256");
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        String fileName;
+        try {
+            JSONObject paperclip = getDownload();
+            fileName = paperclip.getString("name");
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+        String formattedUrl = String.format(downloadUrl, version, build, fileName);
+        updateBuilder.debug("Getting input stream from " + formattedUrl);
+        try {
+            URLConnection connection = UserAgent.CHROME.assignToConnection(WebUtils.createConnection(formattedUrl));
+            return connection.getInputStream();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    @Override
+    public Logger getLogger() {
+        return updateBuilder.logger();
+    }
+}


### PR DESCRIPTION
This PR adds PandaSpigot to the server updater. The API for this Paper fork (fork of 1.8.8 but this one is still being maintained) is almost the same as that of Paper's, with some minor changes. Tested by me and it works. 

With this API, adding a / with nothing behind it makes it give an endpoint not found error, thus I had to change those URLs so it wouldn't add a / when it wasn't needed.